### PR TITLE
[임지수] 7일차 문제 제출 (23827)

### DIFF
--- a/src/23827/23827_python_임지수.py
+++ b/src/23827/23827_python_임지수.py
@@ -1,0 +1,13 @@
+import sys
+
+input = sys.stdin.readline
+
+N = int(input())
+num_lst = list(map(int, input().split()))
+weight_sum = sum(num_lst)
+result = 0
+
+for num in num_lst:
+    weight_sum -= num
+    result += num*weight_sum
+print(result%1000000007)


### PR DESCRIPTION
<aside>
💡 원래 노션에서 혼자 문제풀이했던 방식이 있어서 이번 스터디와 병행해보려 합니다.
</aside>

### ❗접근법

- 1차 접근 : combination을 통한 접근
    
    모든 순서쌍을 리스트에 넣고 누적합을 구했다 ⇒ 메모리, 시간 초과
    
- 2차 접근 : 규칙 발견!
    
  ![image](https://user-images.githubusercontent.com/72483874/189355149-a44da949-32f5-45b5-b345-771af04bc422.png)
    
    순열의 모든 순서쌍의 곱의 누적합 = n번째 원소 * (n+1부터 마지막 원소까지의 합)의 누적합임을 알았다. ⇒ 하지만 시간 초과
    
- 3차 접근 : 해결
    
    뭔가 이상해서 참고해보니 2차 접근에서 구현한 코드가 매 반복마다 sum()을 해주기 때문에 시간 초과가 나는 것임을 깨달았다.(sum()의 복잡도는 O(N))
    
    처음에 한 번의 sum으로 최종 합을 구해놓고 반복마다 해당 숫자를 빼주어서 누적합을 구하는 방법으로 구현하니 시간초과를 해결할 수 있었다.
    

### 📚 고찰

- 수학문제 나오면 케이스에서 숨겨진 규칙 잘 찾기
- weight sum을 활용할 때 매번 sum 하기보다는 한 번의 sum 이후 빼는 방법으로도 구현할 수 있다.