### PR TITLE
[김우헌] 13일차 문제 풀이 (1254)

### DIFF
--- a/src/1254/1254_python_김우헌.py
+++ b/src/1254/1254_python_김우헌.py
@@ -1,0 +1,26 @@
+'''
+baekjoon s2 팰린드롬 만들기
+https://www.acmicpc.net/problem/1254
+2초, 문자열 길이 최대 50
+'''
+
+import sys
+
+input = sys.stdin.readline
+S = input().rstrip()
+result = len(S)
+init_length = len(S)
+
+while True:
+    if result % 2 == 0:
+        compare_length = len(S[result//2:])
+        first = S[:result//2][::-1][:compare_length]
+        second = S[result//2:]
+    else:
+        compare_length = len(S[result//2+1:])
+        first = S[:result//2][::-1][:compare_length]
+        second = S[result//2+1:]
+    if first == second:
+        break
+    result += 1
+print(result)


### PR DESCRIPTION
홀수일때는 가운데 문자를 제외한 앞 뒤 문자를,
짝수일때는 반으로 쪼개 앞 뒤 문자를 비교합니다.

이 문자열에 특정 문자 n개를 더해 만들 수 있는 최소 팰린드롬 길이가 k라고 할 때에
k의 길이를 가지는 팰린드롬을 만들 수 있는지 확인합니다.

원래 문자열의 길이가 6이고, 확인할 k의 값이 7인 경우
길이가 7인 팰린드롬의 가운데 글자는 4번째글자 입니다.
그러므로 원래 문자의 4번째 글자를 기준으로 뒷글자인 5번째 6번째 글자 2개와
앞글자인 3번째, 2번째 글자 2개를 각각 비교해 팰린드롬을 확인합니다.

원래 문자열의 길이가 6이고, 확인할 k의 값이 8인 경우
길이가 8인 짝수 팰린드롬을 확인하기 위해서는
8글자의 뒷 4글자와 앞 4글자를 비교해야하는데, 원래 문자열은 총 6글자이므로
원래문자열의 5, 6번째 문자와 앞 4글자 중 뒤의 두글자인 4, 3번째 글자를 비교해 팰린드롬을 확인합니다.

두서가 없지만 코드와 함께 보신다면 이해하실 수 있을 것 같습니다.