### PR TITLE
[임지수] 11일자 문제 풀이 (17123)

### DIFF
--- a/src/17123/17123_python_임지수.py
+++ b/src/17123/17123_python_임지수.py
@@ -1,0 +1,22 @@
+import sys
+
+input = sys.stdin.readline
+
+T = int(input())                            # number of test cases
+
+for _ in range(T):
+    N, M = map(int, input().split())        # number of rows(columns), parameter case
+    array = [list(map(int, input().split())) for _ in range(N)]
+    
+    sumOfRows = [sum(row) for row in array]
+    sumOfCols = [sum(col) for col in zip(*array)]
+
+    for _ in range(M):
+        r1, c1, r2, c2, v = map(int, input().split())
+        for row in range(r1-1, r2):
+            sumOfRows[row] += v*(c2-c1+1)       # 각 row 별 포함된 column의 개수만큼 v 증감
+        for column in range(c1-1, c2):
+            sumOfCols[column] += v*(r2-r1+1)    # 각 column 별 포함된 row의 개수만큼 v 증감
+        
+    print(*sumOfRows)
+    print(*sumOfCols)


### PR DESCRIPTION
## 😊 풀이

### 🔡 코드

```python
import sys

input = sys.stdin.readline

T = int(input())                            # number of test cases

for _ in range(T):
    N, M = map(int, input().split())        # number of rows(columns), parameter case
    array = [list(map(int, input().split())) for _ in range(N)]
    
    sumOfRows = [sum(row) for row in array]
    sumOfCols = [sum(col) for col in zip(*array)]

    for _ in range(M):
        r1, c1, r2, c2, v = map(int, input().split())
        for row in range(r1-1, r2):
            sumOfRows[row] += v*(c2-c1+1)       # 각 row 별 포함된 column의 개수만큼 v 증감
        for column in range(c1-1, c2):
            sumOfCols[column] += v*(r2-r1+1)    # 각 column 별 포함된 row의 개수만큼 v 증감
        
    print(*sumOfRows)
    print(*sumOfCols)
```

### ❗접근법

문제에 배열의 인덱스를 다루도록 제시되어있고 이를 일일이 참조하는 방법은 무조건 효율성에서 걸릴 것이라고 생각해 다른 방법을 생각했다. 그리고 각 row, col별 합을 출력해야 한다는 것에서 힌트를 얻어 접근한 방법이다.

배열의 인덱스에 v만큼 같은 방법으로 연산해야되는데 어차피 최종적으로 누적된 합을 출력해야 하는 것이면 굳이 그 과정은 구현하지 않아도 된다. 각 row별, col별로 연산에 활용되는 column, row만큼 v가 증감되는 연산이 이루어 진다는 것이므로 처음에 각 row, col의 합을 구해놓고 해당 합의 리스트에 증감되는 v만큼 반영해주면 누적합을 효율적으로 구해낼 수 있다.