### PR TITLE
[임지수] 12일차 문제 풀이 (13702)

### DIFF
--- a/src/13702/13702_python_임지수.py
+++ b/src/13702/13702_python_임지수.py
@@ -1,0 +1,19 @@
+import sys
+
+input = sys.stdin.readline
+
+N, K = map(int, input().split())    # number of 주전자, 사람
+volumeOfKettle = [int(input()) for _ in range(N)]
+start, end = 1, sum(volumeOfKettle) // K                # max는 주전자 총 합을 K만큼 나눠줄 수 있는 값
+
+while start <= end:
+    mid = (start+end)//2                                
+
+    result = sum([i//mid for i in volumeOfKettle])      # mid만큼 나눠줬을 때 총 줄 수 있는 사람 수 
+
+    if result >= K:                                     # K보다 크면 더 나눠줄 수 있으므로 mid+1 부터 다시 탐색
+        start = mid+1
+    else:                                               # 작으면 나눠주는 용량을 낮춰야 하므로 mid-1까지로 조정 후 탐색
+        end = mid-1
+
+print(end)                                              # 탐색이 끝나면 end값이 K명에게 나눠줄 수 있는 최대의 값


### PR DESCRIPTION
### ⚡ 본 풀이는 문제의 이진탐색을 활용한 풀이를 참고했음을 밝힙니다.

## 🤔 풀이

### 🔡 코드

```python
import sys

input = sys.stdin.readline

N, K = map(int, input().split())    # number of 주전자, 사람
volumeOfKettle = [int(input()) for _ in range(N)]
start, end = 1, sum(volumeOfKettle) // K                # max는 주전자 총 합을 K만큼 나눠줄 수 있는 값

while start <= end:
    mid = (start+end)//2                                

    result = sum([i//mid for i in volumeOfKettle])      # mid만큼 나눠줬을 때 총 줄 수 있는 사람 수 

    if result >= K:                                     # K보다 크면 더 나눠줄 수 있으므로 mid+1 부터 다시 탐색
        start = mid+1
    else:                                               # 작으면 나눠주는 용량을 낮춰야 하므로 mid-1까지로 조정 후 탐색
        end = mid-1

print(end)                                              # 탐색이 끝나면 end값이 K명에게 나눠줄 수 있는 최대의 값
```

### ⚠️ 접근법

- 1차 접근
    
    ```python
    import sys
    
    input = sys.stdin.readline
    
    N, K = map(int, input().split())    # number of 주전자, 사람
    volumeOfKettle = [int(input()) for _ in range(N)]
    canSplitVolume = sum(volumeOfKettle) // K
    
    while canSplitVolume:
        if sum([i//canSplitVolume for i in volumeOfKettle]) == K:
            break
        else: canSplitVolume -= 1
    
    print(canSplitVolume)
    ```
    
    - 나눠줄 수 있는 max 값(전체 막걸리 용량의 합을 K로 나눈 값 : canSplitVolume)에서 1씩 낮춰가며 나눠줬을 때 처음으로 K명에게 나눠줄 수 있는 값 = 가장 많은 사람에게 나눠줄 수 있는 용량
    - 시간초과
- 2차 접근
    - 1차 접근에서 canSplitVolumn을 1씩 낮춰서 탐색하는 과정을 이진 탐색으로 구현해보자
    - 1 ~ canSplitVolume만큼 나눠줄 수 있고, 이 구간이 이진탐색의 start와 end 구간
        - 테스트케이스에 용량이 0인 경우도 있어서 0부터 구간을 지정하면 ZeroDivisionError
    - mid만큼 나눠줬을 때 총 줄 수 있는 사람 수가 K 이상이면 더 나눠줄 수 있으므로 탐색 시작 구간을 mid+1로 조정(1보다 더 나눠줄 수 있다)
    - K 아래이면 나눠주는 용량을 줄여야 하므로 탐색 종료 구간을 mid-1로 조정

## 📚 고찰

- 정렬된 구간 안의 값을 활용하고, 그 적절한 값을 찾아야 할 때 이제 이진 탐색은 선택이 아닌 필수인 것 같다.
- 이진탐색을 적용했을 때 당장 제시된 케이스에서는 더 비효율이라고 느낄 수 있지만 채점시 활용되는 케이스는 굉장히 극단적인 값이 들어감을 인지하자.
- 한 번 더 이진탐색 알고리즘 구현하는 거 찾아보면 나 바보임