### PR TITLE
[임지수] 14일차 문제 풀이 (21938)

### DIFF
--- a/src/21938/21938_python_임지수.py
+++ b/src/21938/21938_python_임지수.py
@@ -1,0 +1,35 @@
+import sys
+from collections import deque
+
+def bfs(i, j):
+    q = deque([(i, j)])
+    while q:
+        x, y = q.popleft()
+        for d_x, d_y in zip(dx, dy):
+            nx, ny = x+d_x, y+d_y
+            if 0 <= nx < N and 0 <= ny < M and lst[nx][ny] and not visited[nx][ny]:
+                visited[nx][ny] = True
+                q.append((nx, ny))
+    return 1
+
+input = sys.stdin.readline
+
+N, M = map(int, input().split())
+lst = [list(map(int, input().split())) for _ in range(N)]
+th = int(input())
+
+lst = [[sum(row[(3*i):(3*i+3)])/3 for i in range(M)] for row in lst] # 각 픽셀별 채널 평균
+lst = [[255 if i >= th else 0 for i in row] for row in lst]          # 각 픽셀별 이진화
+
+cnt = 0
+
+visited = [[False for _ in range(M)] for _ in range(N)]
+dx = [0, 0, 1, -1] 
+dy = [1, -1, 0, 0]
+
+for i in range(N):
+    for j in range(M):
+        if lst[i][j] and not visited[i][j]:
+            cnt += bfs(i, j)
+   
+print(cnt)


### PR DESCRIPTION
## 😊 풀이

### 🔡 코드

```python
import sys
from collections import deque

def bfs(i, j):
    q = deque([(i, j)])
    while q:
        x, y = q.popleft()
        for d_x, d_y in zip(dx, dy):
            nx, ny = x+d_x, y+d_y
            if 0 <= nx < N and 0 <= ny < M and lst[nx][ny] and not visited[nx][ny]:
                visited[nx][ny] = True
                q.append((nx, ny))
    return 1

input = sys.stdin.readline

N, M = map(int, input().split())
lst = [list(map(int, input().split())) for _ in range(N)]
th = int(input())

lst = [[sum(row[(3*i):(3*i+3)])/3 for i in range(M)] for row in lst] # 각 픽셀별 채널 평균
lst = [[255 if i >= th else 0 for i in row] for row in lst]          # 각 픽셀별 이진화

cnt = 0

visited = [[False for _ in range(M)] for _ in range(N)]
dx = [0, 0, 1, -1] 
dy = [1, -1, 0, 0]

for i in range(N):
    for j in range(M):
        if lst[i][j] and not visited[i][j]:
            cnt += bfs(i, j)
   
print(cnt)
```

### ❗접근법

초반 조금 복잡한 입력과정이 있어 뭔가 싶었지만 간단한 연산으로 입력받을 수 있었고, 그 이후에는 그래프 탐색으로 전형적인 DFS/BFS문제인 것 같아 BFS로 접근했다.

처음에 너무 그래프 탐색에만 집착하다 보니 문제 본질을 놓쳐 헤맸었는데, 255로 연결된 경로를 모두 찾아야된다는 점에서 리스트 내 모든 인덱스를 순회하며 BFS를 해야했고, BFS를 진행하며 방문했던 인덱스는 재방문하지 않아야 한다는 점까지 고려해야 문제를 해결할 수 있었다.

## 📚 고찰

- 문제의 본질, 요지를 잘 파악해서 처음부터 고려하자
- 뭔가 순환함수 만드는 게 거부감 느껴져서 맨날 BFS로 접근하게 되는데 언젠가 DFS가 필요한 날이 오지 않을까..? 해서 다음에는 DFS로 꼭 접근해보자.
- 혹시 BFS가 아닌 DFS로 그래프 탐색을 해야하는 유형이 있다면 알려주세효!