### PR TITLE
[김우헌] 23일차 문제 제출 (24393)

### DIFF
--- a/src/24393/24393_python_김우헌.py
+++ b/src/24393/24393_python_김우헌.py
@@ -1,0 +1,27 @@
+'''
+baekjoon s3 조커 찾기
+https://www.acmicpc.net/problem/24393
+'''
+
+import sys
+
+input = sys.stdin.readline
+
+N = int(input())
+cards = [i for i in range(27)]
+joker = 0
+for i in range(N):
+    shuffle_sequence = list(map(int, input().split()))
+    left = cards[:13]
+    right = cards[13:]
+    new_cards = []
+    for k in range(len(shuffle_sequence)):
+        if k % 2 == 0:
+            new_cards += right[:shuffle_sequence[k]]
+            right = right[shuffle_sequence[k]:]
+        else:
+            new_cards += left[:shuffle_sequence[k]]
+            left = left[shuffle_sequence[k]:]
+    cards = new_cards.copy()
+print(cards.index(0)+1)
+


### PR DESCRIPTION
시뮬레이션 문제입니다.
카드를 왼쪽 13장 | 오른쪽 14장 으로 나눈 뒤
문제에서 주어진 셔플을 위한 순열을 바탕으로
카드를 섞습니다. 리스트 슬라이싱을 통해 간단하게 구현했습니다.