### PR TITLE
[임지수] 16일차 문제 제출 (18232)

### DIFF
--- a/src/18232/18232_python_임지수.py
+++ b/src/18232/18232_python_임지수.py
@@ -1,0 +1,36 @@
+import sys
+from collections import deque, defaultdict
+
+input = sys.stdin.readline
+
+N, M = map(int, input().split())    # N : 점 개수, M : 텔레포트 정거장 개수
+S, E = map(int, input().split())    # S : 현위치, E : 목적지
+
+teleportGates = defaultdict(deque)
+
+for _ in range(M):
+    g1, g2 = map(int, input().split())
+    teleportGates[g1].append(g2)
+    teleportGates[g2].append(g1)    # 양방향 이동 고려
+
+load = [False for _ in range(1, N+2)]   # 인덱스 0 제외하고 생각할 것
+q = deque([(S, 0)])     # S에서 출발(cnt = 0)
+load[S] = True
+
+while q:
+    st, cnt = q.popleft()
+    if st == E:
+        break
+    if 0 < st+1 <= N and not load[st+1]:
+        load[st+1] = True
+        q.append((st+1, cnt+1))
+    if 0 < st-1 <= N and not load[st-1]:
+        load[st-1] = True
+        q.append((st-1, cnt+1))
+    if st in teleportGates:
+        for dt in teleportGates[st]:
+            if not load[dt]:
+                load[dt] = True
+                q.append((dt, cnt+1))
+
+print(cnt)


### PR DESCRIPTION
## 😊 풀이

### 🔡 코드

```python
import sys
from collections import deque, defaultdict

input = sys.stdin.readline

N, M = map(int, input().split())    # N : 점 개수, M : 텔레포트 정거장 개수
S, E = map(int, input().split())    # S : 현위치, E : 목적지

teleportGates = defaultdict(deque)

for _ in range(M):
    g1, g2 = map(int, input().split())
    teleportGates[g1].append(g2)
    teleportGates[g2].append(g1)    # 양방향 이동 고려

load = [False for _ in range(1, N+2)]   # 인덱스 0 제외하고 생각할 것
q = deque([(S, 0)])     # S에서 출발(cnt = 0)
load[S] = True

while q:
    st, cnt = q.popleft()
    if st == E:
        break
    if 0 < st+1 <= N and not load[st+1]:
        load[st+1] = True
        q.append((st+1, cnt+1))
    if 0 < st-1 <= N and not load[st-1]:
        load[st-1] = True
        q.append((st-1, cnt+1))
    if st in teleportGates:
        for dt in teleportGates[st]:
            if not load[dt]:
                load[dt] = True
                q.append((dt, cnt+1))

print(cnt)
```

### ❕접근법

한 줄짜리 그래프 탐색 문제이다..! 처음에 순환함수로 구현하려다가 너무 복잡해지고 머리도 너무 아팠어서 익숙한 반복문으로 풀게 되었다..!

이 문제에서 특별히 고려해야할 점은

- 다음에 갈 지점이 유효한 지점인가
- 다음에 갈 지점이 이미 방문 되었는가
    - 이미 방문되었다면 현재 방향에서 간 방법은 최소 방법이 아니다!
- 텔레포트 정거장도 위를 동일하게 적용하되, 양방향 이동을 고려해야한다는 점
- 큐에 append할 때 해당 점을 방문처리하지 않으면 여러번 불필요한 이동을 연산하는 과정에서 시간초과가 난다는 점!

이다..! 이를 모두 고려하면 문제가 해결되었다. 

### 📚 고찰

예전에는 그래프 탐색 문제에 알고리즘을 적용할 때 대부분 구현하지 못했었는데, 이제 단순한 접근에서 활용할 수 있게 되었다. 특히 다음 이동할 점과 함께 카운트 정보도 함께 전달한다는 아이디어를 자연스럽게 떠올린 점을 봐서 조금은 성장하지 않았을까 조심스럽게 생각한다..! 화이팅