### PR TITLE
[임지수] 18일차 문제 제출 (6198)

### DIFF
--- a/src/6198/6198_python_임지수.py
+++ b/src/6198/6198_python_임지수.py
@@ -1,0 +1,19 @@
+import sys
+from collections import deque
+
+
+input = sys.stdin.readline
+
+N = int(input())
+bulidings = deque([int(input()) for _ in range(N)])
+stack = deque()
+iCanSee = 0
+
+for buliding in bulidings:
+    while stack and stack[-1] <= buliding:
+        stack.pop()
+    iCanSee += len(stack)
+    stack.append(buliding)
+
+print(iCanSee)
+


### PR DESCRIPTION
## 💡본 풀이는 [[여기](https://velog.io/@thguss/%EB%B0%B1%EC%A4%80-6198.-%EC%98%A5%EC%83%81-%EC%A0%95%EC%9B%90-%EA%BE%B8%EB%AF%B8%EA%B8%B0-with.-Python)]를 참고했음을 밝힙니다.

## 👿 풀이

### 🔡 코드

```python
import sys
from collections import deque

input = sys.stdin.readline

N = int(input())
bulidings = deque([int(input()) for _ in range(N)])
stack = deque()
iCanSee = 0

for buliding in bulidings:
    while stack and stack[-1] <= buliding:
        stack.pop()
    iCanSee += len(stack)
    stack.append(buliding)

print(iCanSee)
```

### ⚠️ 접근법

- 1차 접근 : 2중 루프
    - 입력을 받음과 동시에 해당 빌딩이 들어서기 전까지의 빌딩들을 탐색하며 들어선 건물들이 해당 건물을 볼 수 있는지 검사
    - 한 번 빌딩을 못보면 다음꺼는 다 못봄 ⇒ 새로 건물이 들어서면 그 건물을 기존 건물들이 볼 수 있는지 검사하는 boolean 배열 활용
    - 시간초과
- 2차 접근 : 두개의 deque 활용
    - 입력을 받음과 동시에 해당 빌딩이 들어서기 전까지 빌딩들을 저장한 q1에서 하나씩 pop
    - pop한 값과 입력 받은 빌딩을 비교해서 pop한 값이 더 큰 경우에만 q2로 append
    - q2의 길이만큼 결과 변수(iCanSee)를 증가시키고 q1 ← q2(q2는 입력 받을때마다 초기화)
    - 시간초과
- 3차 접근(참고) : 스택 활용
    
    입력을 전부 받아서 빌딩별로 순회한다. 빌딩을 순회하면서 stack을 활용하는데, 기본적으로 빌딩을 순회할때마다 stack에 빌딩을 append 해주는데, 그 전에 stack에 있는 빌딩들을 뒤에서부터 탐색하여 맨 뒤 빌딩이 이제 들어올 빌딩을 볼 수 있는지를 검사하여 볼 수 없으면 pop연산을 해준다. 즉, 이 과정을 거치면 stack에 있는 빌딩들은 이제 들어올 빌딩들을 볼 수 있다는 것이므로  stack의 길이만큼 결과 변수를 증가시켜준다.
    

## 📚 고찰

새로 들어올 빌딩을 지금까지 들어올 빌딩이 볼 수 있는지를 검사하여 그만큼 결과 변수를 늘려준다라는 아이디어는 모두 비슷했지만 구현 과정에서 스택을 효율적으로 사용하지 않으면 시간초과가 나버리는 문제였다. 이 문제에서 배우게 된 점은 문제 해결 방법을 앞에서부터 순차적으로만 생각하지 말고 안풀리면 뒤에서부터 접근도 생각해봐야 한다는 점이다.